### PR TITLE
Stop unidentified ObjectDisposedExceptions causing so much havok

### DIFF
--- a/DarkRift.Client/BichannelClientConnection.cs
+++ b/DarkRift.Client/BichannelClientConnection.cs
@@ -316,7 +316,7 @@ namespace DarkRift.Client
                     }
                     catch (ObjectDisposedException)
                     {
-                        HandleDisconnectionDuringHeaderReceive(null);
+                        HandleDisconnectionDuringHeaderReceive(args);
                         return;
                     }
 
@@ -336,7 +336,7 @@ namespace DarkRift.Client
                     }
                     catch (ObjectDisposedException)
                     {
-                        HandleDisconnectionDuringBodyReceive(null);
+                        HandleDisconnectionDuringBodyReceive(args);
                         return;
                     }
 
@@ -363,7 +363,7 @@ namespace DarkRift.Client
                 }
                 catch (ObjectDisposedException)
                 {
-                    HandleDisconnectionDuringHeaderReceive(null);
+                    HandleDisconnectionDuringHeaderReceive(args);
                     return;
                 }
 
@@ -413,7 +413,7 @@ namespace DarkRift.Client
                 }
                 catch (ObjectDisposedException)
                 {
-                    HandleDisconnectionDuringBodyReceive(null);
+                    HandleDisconnectionDuringBodyReceive(args);
                     return;
                 }
             }
@@ -429,7 +429,7 @@ namespace DarkRift.Client
             }
             catch (ObjectDisposedException)
             {
-                HandleDisconnectionDuringHeaderReceive(null);
+                HandleDisconnectionDuringHeaderReceive(args);
                 return;
             }
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
@@ -236,7 +236,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
                     }
                     catch (ObjectDisposedException)
                     {
-                        HandleDisconnectionDuringHeaderReceive(null);
+                        HandleDisconnectionDuringHeaderReceive(args);
                         return;
                     }
 
@@ -261,7 +261,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
                     }
                     catch (ObjectDisposedException)
                     {
-                        HandleDisconnectionDuringBodyReceive(null);
+                        HandleDisconnectionDuringBodyReceive(args);
                         return;
                     }
 
@@ -288,7 +288,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
                 }
                 catch (ObjectDisposedException)
                 {
-                    HandleDisconnectionDuringHeaderReceive(null);
+                    HandleDisconnectionDuringHeaderReceive(args);
                     return;
                 }
 
@@ -338,7 +338,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
                 }
                 catch (ObjectDisposedException)
                 {
-                    HandleDisconnectionDuringBodyReceive(null);
+                    HandleDisconnectionDuringBodyReceive(args);
                     return;
                 }
             }
@@ -354,7 +354,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             }
             catch (ObjectDisposedException)
             {
-                HandleDisconnectionDuringHeaderReceive(null);
+                HandleDisconnectionDuringHeaderReceive(args);
                 return;
             }
 


### PR DESCRIPTION
Fixes #126 by just catvhing the exception. It might be there's something better that could be added to the `WasXXXReceiveSuccessful` methods but without being able to reproduce the error it'll be hard to work that out