### PR TITLE
Dispose messageBuffers where they fail to send

### DIFF
--- a/DarkRift.Client/BichannelClientConnection.cs
+++ b/DarkRift.Client/BichannelClientConnection.cs
@@ -205,7 +205,10 @@ namespace DarkRift.Client
         public override bool SendMessageReliable(MessageBuffer message)
         {
             if (connectionState == ConnectionState.Disconnected)
+            {
+                message.Dispose();
                 return false;
+            }
 
             byte[] header = new byte[4];
             BigEndianHelper.WriteBytes(header, 0, message.Count);
@@ -229,6 +232,7 @@ namespace DarkRift.Client
             }
             catch (Exception)
             {
+                message.Dispose();
                 return false;
             }
 
@@ -242,7 +246,10 @@ namespace DarkRift.Client
         public override bool SendMessageUnreliable(MessageBuffer message)
         {
             if (connectionState == ConnectionState.Disconnected)
+            {
+                message.Dispose();
                 return false;
+            }
 
             SocketAsyncEventArgs args = ObjectCache.GetSocketAsyncEventArgs();
             args.BufferList = null;
@@ -258,6 +265,7 @@ namespace DarkRift.Client
             }
             catch (Exception)
             {
+                message.Dispose();
                 return false;
             }
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListener.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListener.cs
@@ -173,6 +173,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             catch (Exception e)
             {
                 Logger.Warning("UDP send failed as an exception was thrown.", e);
+                message.Dispose();
                 return false;
             }
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
@@ -141,7 +141,10 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
         public override bool SendMessageReliable(MessageBuffer message)
         {
             if (!CanSend)
+            {
+                message.Dispose();
                 return false;
+            }
 
             byte[] header = new byte[4];        // TODO pool!
             BigEndianHelper.WriteBytes(header, 0, message.Count);
@@ -166,6 +169,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             }
             catch (Exception)
             {
+                message.Dispose();
                 return false;
             }
 
@@ -179,7 +183,10 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
         public override bool SendMessageUnreliable(MessageBuffer message)
         {
             if (!CanSend)
+            {
+                message.Dispose();
                 return false;
+            }
             
             return networkListener.SendUdpBuffer(RemoteUdpEndPoint, message, UdpSendCompleted);
         }


### PR DESCRIPTION
As discussed in https://github.com/DarkRiftNetworking/DarkRift/issues/144; done in two commits that match the posts in the thread.