### PR TITLE
Dispose message buffers on fail

### DIFF
--- a/DarkRift.Client/BichannelClientConnection.cs
+++ b/DarkRift.Client/BichannelClientConnection.cs
@@ -233,6 +233,8 @@ namespace DarkRift.Client
             catch (Exception)
             {
                 message.Dispose();
+                args.Completed += TcpSendCompleted;
+                ObjectCache.ReturnSocketAsyncEventArgs(args);
                 return false;
             }
 
@@ -266,6 +268,8 @@ namespace DarkRift.Client
             catch (Exception)
             {
                 message.Dispose();
+                args.Completed -= UdpSendCompleted;
+                ObjectCache.ReturnSocketAsyncEventArgs(args);
                 return false;
             }
 

--- a/DarkRift.Client/BichannelClientConnection.cs
+++ b/DarkRift.Client/BichannelClientConnection.cs
@@ -205,7 +205,10 @@ namespace DarkRift.Client
         public override bool SendMessageReliable(MessageBuffer message)
         {
             if (connectionState == ConnectionState.Disconnected)
+            {
+                message.Dispose();
                 return false;
+            }
 
             byte[] header = new byte[4];
             BigEndianHelper.WriteBytes(header, 0, message.Count);
@@ -229,6 +232,7 @@ namespace DarkRift.Client
             }
             catch (Exception)
             {
+                message.Dispose();
                 return false;
             }
 
@@ -242,7 +246,10 @@ namespace DarkRift.Client
         public override bool SendMessageUnreliable(MessageBuffer message)
         {
             if (connectionState == ConnectionState.Disconnected)
+            {
+                message.Dispose();
                 return false;
+            }
 
             SocketAsyncEventArgs args = ObjectCache.GetSocketAsyncEventArgs();
             args.BufferList = null;
@@ -258,6 +265,7 @@ namespace DarkRift.Client
             }
             catch (Exception)
             {
+                message.Dispose();
                 return false;
             }
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListener.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListener.cs
@@ -174,6 +174,8 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             {
                 Logger.Warning("UDP send failed as an exception was thrown.", e);
                 message.Dispose();
+                args.Completed -= UdpSendCompleted;
+                ObjectCache.ReturnSocketAsyncEventArgs(args);
                 return false;
             }
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListener.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListener.cs
@@ -173,6 +173,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             catch (Exception e)
             {
                 Logger.Warning("UDP send failed as an exception was thrown.", e);
+                message.Dispose();
                 return false;
             }
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
@@ -141,7 +141,10 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
         public override bool SendMessageReliable(MessageBuffer message)
         {
             if (!CanSend)
+            {
+                message.Dispose();
                 return false;
+            }
 
             byte[] header = new byte[4];        // TODO pool!
             BigEndianHelper.WriteBytes(header, 0, message.Count);
@@ -166,6 +169,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             }
             catch (Exception)
             {
+                message.Dispose();
                 return false;
             }
 
@@ -179,7 +183,10 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
         public override bool SendMessageUnreliable(MessageBuffer message)
         {
             if (!CanSend)
+            {
+                message.Dispose();
                 return false;
+            }
             
             return networkListener.SendUdpBuffer(RemoteUdpEndPoint, message, UdpSendCompleted);
         }

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
@@ -170,6 +170,8 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             catch (Exception)
             {
                 message.Dispose();
+                args.Completed -= TcpSendCompleted;
+                ObjectCache.ReturnSocketAsyncEventArgs(args);
                 return false;
             }
 


### PR DESCRIPTION
As per https://github.com/DarkRiftNetworking/DarkRift/issues/144

Identified additional buffers that were not getting cleared if messages failed to send (e.g. Client Disconnected while message already "in flight") compared to fist pull request. 