### PR TITLE
Added the property PreserveTcpOrdering

### DIFF
--- a/DarkRift.Server/Plugins/Listeners/Bichannel/AbstractBichannelListener.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/AbstractBichannelListener.cs
@@ -25,6 +25,11 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
         public abstract bool NoDelay { get; set; }
 
         /// <summary>
+        ///     If true (default), reliable messages are delivered in order. If false, reliable messages can be delivered out of order to improve performance.
+        /// </summary>
+        public abstract bool PreserveTcpOrdering { get; protected set; }
+
+        /// <summary>
         ///     The maximum size the client can ask a TCP body to be without being striked.
         /// </summary>
         /// <remarks>This defaults to 65KB.</remarks>

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
@@ -98,6 +98,9 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             else
                 this.UdpPort = this.Port;
 
+            var preserveTcpOrdering = listenerLoadData.Settings["preserveTcpOrdering"]?.ToLower();
+            this.PreserveTcpOrdering = preserveTcpOrdering == null || preserveTcpOrdering == "true"; // keep this true by default, but if user specifies it in config they probably want to disable it
+
             TcpListener = new Socket(Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             UdpListener = new Socket(Address.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
@@ -41,6 +41,11 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
         }
 
         /// <summary>
+        ///     If true (default), reliable messages are delivered in order. If false, reliable messages can be delivered out of order to improve performance.
+        /// </summary>
+        public override bool PreserveTcpOrdering { get; protected set; } = true;
+
+        /// <summary>
         ///     Dictionary of TCP connections awaiting their UDP counterpart.
         /// </summary>
         protected Dictionary<long, PendingConnection> PendingTcpSockets { get; } = new Dictionary<long, PendingConnection>();

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelServerConnection.cs
@@ -47,6 +47,8 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             set => tcpSocket.NoDelay = value;
         }
 
+        private bool PreserveTcpOrdering => networkListener.PreserveTcpOrdering;
+
         /// <summary>
         ///     The token used to authenticate this user's UDP connection.
         /// </summary>
@@ -271,6 +273,9 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
                 
                 MessageBuffer bodyBuffer = ProcessBody(args);
 
+                if (PreserveTcpOrdering)
+                    ProcessMessage(bodyBuffer);
+
                 // Start next receive before invoking events
                 SetupReceiveHeader(args);
                 bool headerCompletingAsync;
@@ -284,7 +289,8 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
                     return;
                 }
 
-                ProcessMessage(bodyBuffer);
+                if (!PreserveTcpOrdering)
+                    ProcessMessage(bodyBuffer);
 
                 if (headerCompletingAsync)
                     return;
@@ -337,6 +343,9 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
 
             MessageBuffer bodyBuffer = ProcessBody(args);
 
+            if (PreserveTcpOrdering)
+                ProcessMessage(bodyBuffer);
+
             // Start next receive before invoking events
             SetupReceiveHeader(args);
             bool headerCompletingAsync;
@@ -350,7 +359,8 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
                 return;
             }
 
-            ProcessMessage(bodyBuffer);
+            if (!PreserveTcpOrdering)
+                ProcessMessage(bodyBuffer);
 
             if (headerCompletingAsync)
                 return;

--- a/DarkRift.SystemTesting/ReliableOrderTest.cs
+++ b/DarkRift.SystemTesting/ReliableOrderTest.cs
@@ -33,7 +33,7 @@ namespace DarkRift.SystemTesting
                 server.ClientManager.GetAllClients()[0].SendMessage(message, SendMode.Reliable);
             }
 
-            SendBunchOfMessagesToAndExpectOrderedArrival(SetupReceiver, Send);
+            SendBunchOfMessagesAndExpectOrderedArrival(SetupReceiver, Send);
         }
 
         [TestMethod]
@@ -60,10 +60,10 @@ namespace DarkRift.SystemTesting
                 client.SendMessage(message, SendMode.Reliable);
             }
 
-            SendBunchOfMessagesToAndExpectOrderedArrival(SetupReceiver, Send);
+            SendBunchOfMessagesAndExpectOrderedArrival(SetupReceiver, Send);
         }
 
-        private void SendBunchOfMessagesToAndExpectOrderedArrival(Action<DarkRiftClient, DarkRiftServer, Action<Message>> setupReceiver, Action<DarkRiftClient, DarkRiftServer, Message> send)
+        private void SendBunchOfMessagesAndExpectOrderedArrival(Action<DarkRiftClient, DarkRiftServer, Action<Message>> setupReceiver, Action<DarkRiftClient, DarkRiftServer, Message> send)
         {
             var spawnData = ServerSpawnData.CreateFromXml("Configurations/Server/Server.config", new NameValueCollection());
             spawnData.EventsFromDispatcher = false;

--- a/DarkRift.SystemTesting/ReliableOrderTest.cs
+++ b/DarkRift.SystemTesting/ReliableOrderTest.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Xml.Schema;
+using DarkRift.Client;
+using DarkRift.Server;
+using DarkRift.Server.Plugins.Listeners.Bichannel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DarkRift.SystemTesting
+{
+    [TestClass]
+    public class ReliableOrderTest
+    {
+        [TestMethod]
+        public void SendBunchOfMessagesAndExpectOrderedArrivalAtClient()
+        {
+            void SetupReceiver(DarkRiftClient client, DarkRiftServer server, Action<Message> handler)
+            {
+                void MessageReceived(object sender, Client.MessageReceivedEventArgs e)
+                {
+                    using var message = e.GetMessage();
+                    handler(message);
+                }
+
+                client.MessageReceived += MessageReceived;
+            }
+
+            void Send(DarkRiftClient client, DarkRiftServer server, Message message)
+            {
+                server.ClientManager.GetAllClients()[0].SendMessage(message, SendMode.Reliable);
+            }
+
+            SendBunchOfMessagesToAndExpectOrderedArrival(SetupReceiver, Send);
+        }
+
+        [TestMethod]
+        public void SendBunchOfMessagesAndExpectOrderedArrivalAtServer()
+        {
+            void SetupReceiver(DarkRiftClient client, DarkRiftServer server, Action<Message> handler)
+            {
+                void ClientConnected(object sender, ClientConnectedEventArgs e)
+                {
+                    void MessageReceived(object sender, Server.MessageReceivedEventArgs e)
+                    {
+                        using var message = e.GetMessage();
+                        handler(message);
+                    }
+
+                    e.Client.MessageReceived += MessageReceived;
+                }
+
+                server.ClientManager.ClientConnected += ClientConnected;
+            }
+
+            void Send(DarkRiftClient client, DarkRiftServer server, Message message)
+            {
+                client.SendMessage(message, SendMode.Reliable);
+            }
+
+            SendBunchOfMessagesToAndExpectOrderedArrival(SetupReceiver, Send);
+        }
+
+        private void SendBunchOfMessagesToAndExpectOrderedArrival(Action<DarkRiftClient, DarkRiftServer, Action<Message>> setupReceiver, Action<DarkRiftClient, DarkRiftServer, Message> send)
+        {
+            var spawnData = ServerSpawnData.CreateFromXml("Configurations/Server/Server.config", new NameValueCollection());
+            spawnData.EventsFromDispatcher = false;
+
+            using var client = new DarkRiftClient();
+            using var server = new DarkRiftServer(spawnData);
+
+            const int NoDiff = -1;
+
+            int receiveCount = 0;
+            int sendCount = 0;
+            int diffAt = NoDiff;
+
+            void MessageReceived(Message message)
+            {
+                using var reader = message.GetReader();
+
+                int receivedNumber = reader.ReadInt32();
+                int expectedReceive = receiveCount;
+
+                if (expectedReceive != receivedNumber && diffAt == NoDiff)
+                {
+                    //can't do asserts on other thread so defer to main thread
+                    diffAt = expectedReceive;
+                }
+
+                Interlocked.Increment(ref receiveCount);
+            }
+
+            setupReceiver(client, server, MessageReceived);
+
+            server.StartServer();
+            var listener = (AbstractBichannelListener)server.NetworkListenerManager.GetAllNetworkListeners().First();
+            int port = listener.Port;
+            int udpPort = listener.UdpPort;
+            client.Connect(IPAddress.Parse("127.0.0.1"), port, udpPort, true);
+
+            Assert.AreEqual(ConnectionState.Connected, client.ConnectionState);
+            Assert.AreEqual(1, server.ClientManager.Count);
+
+            for (int i = 0; i < 100000; ++i)
+            {
+                using var writer = DarkRiftWriter.Create(40);
+
+                writer.Write(sendCount);
+                Interlocked.Increment(ref sendCount);
+
+                using var message = Message.Create(0, writer);
+
+                send(client, server, message);
+            }
+
+            Thread.Sleep(2000); //give receiver time to catch up
+
+            Assert.AreEqual(sendCount, receiveCount, "Not all messages sent!");
+            Assert.AreEqual(NoDiff, diffAt, "Received in different order");
+        }
+    }
+}


### PR DESCRIPTION
...it defaults to true, which then disables the BichannelListener performance enhancement to start reading another reliable message while another is being processed (impact deemed negligible for almost all games, and we don't want people who aren't aware of it to be surprised by the behavior and report bugs). Added a test that previously failed before this change due to out of order TCP delivery.