### PR TITLE
Fix for #130: Turkish ISP deletes empty UDP Packages

### DIFF
--- a/DarkRift.Client/BichannelClientConnection.cs
+++ b/DarkRift.Client/BichannelClientConnection.cs
@@ -146,9 +146,21 @@ namespace DarkRift.Client
                 //Receive auth token from TCP
                 byte[] buffer = new byte[9];
                 tcpSocket.ReceiveTimeout = 5000;
-                int receivedTcp = tcpSocket.Receive(buffer);
-                tcpSocket.ReceiveTimeout = 0;   //Reset to infinite
 
+                int receivedTcp;
+                try
+                {
+                    receivedTcp = tcpSocket.Receive(buffer);
+                }
+                catch (SocketException ex)
+                {
+                    throw new DarkRiftConnectionException("TCP auth token reception timeout", ex);
+                }
+                finally
+                {
+                    tcpSocket.ReceiveTimeout = 0;   //Reset to infinite
+                }
+                
                 if (receivedTcp != 9 || buffer[0] != 0)
                 {
                     tcpSocket.Shutdown(SocketShutdown.Both);
@@ -161,8 +173,20 @@ namespace DarkRift.Client
                 //Receive response from server to initiate the connection
                 buffer = new byte[1];
                 udpSocket.ReceiveTimeout = 5000;
-                int receivedUdp = udpSocket.Receive(buffer);
-                udpSocket.ReceiveTimeout = 0;   //Reset to infinite
+                
+                int receivedUdp;
+                try
+                {
+                    receivedUdp = udpSocket.Receive(buffer);
+                }
+                catch (SocketException ex)
+                {
+                    throw new DarkRiftConnectionException("UDP auth token reception error", ex);
+                }
+                finally
+                {
+                    udpSocket.ReceiveTimeout = 0;   //Reset to infinite
+                }
 
                 if (receivedUdp != 1 || buffer[0] != 0)
                 {

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
@@ -282,9 +282,11 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
 
                 // Send message back to client to say hi
                 // This MemoryBuffer is not supposed to be disposed here! It's disposed when the message is sent!
-                MessageBuffer helloBuffer = MessageBuffer.Create(1);
-                helloBuffer.Count = 1;
-                helloBuffer.Buffer[0] = 0;                          // Layout: 0 - Version
+                const int NumBytesOfHello = 8; // This used to be 1 which caused issues with some ISPs.
+                MessageBuffer helloBuffer = MessageBuffer.Create(NumBytesOfHello);
+                helloBuffer.Count = NumBytesOfHello;
+                for (int i = 0; i < NumBytesOfHello; ++i)
+                    helloBuffer.Buffer[i] = buffer.Buffer[i + 1];
                 connection.SendMessageUnreliable(helloBuffer);
 
                 //Inform everyone

--- a/DarkRift.SystemTesting/PartialMessagingSteps.cs
+++ b/DarkRift.SystemTesting/PartialMessagingSteps.cs
@@ -69,21 +69,22 @@ namespace DarkRift.SystemTesting
         public void GivenTheHandshakeHasCompeleted()
         {
             // Receive token
-            byte[] buffer = new byte[9];
-            int receivedTcp = tcpSocket.Receive(buffer);
+            byte[] tcpBuffer = new byte[9];
+            int receivedTcp = tcpSocket.Receive(tcpBuffer);
 
             Assert.AreEqual(9, receivedTcp);
-            Assert.AreEqual(0, buffer[0]);
+            Assert.AreEqual(0, tcpBuffer[0]);
 
             // Return token
-            udpSocket.Send(buffer);
+            udpSocket.Send(tcpBuffer);
 
             // Receive punchthrough
-            byte[] buffer2 = new byte[1];
-            int receivedUdp = udpSocket.Receive(buffer);
+            byte[] udpBuffer = new byte[8];
+            int receivedUdp = udpSocket.Receive(udpBuffer);
 
-            Assert.AreEqual(1, receivedUdp);
-            Assert.AreEqual(0, buffer2[0]);
+            Assert.AreEqual(8, receivedUdp);
+            for (int i = 0; i < 8; ++i)
+                Assert.AreEqual(tcpBuffer[i + 1], udpBuffer[i], $"Token byte {i} mismatch");
 
             // Stupid race condition to attach the MessageReceived handler
             System.Threading.Thread.Sleep(100);


### PR DESCRIPTION
Decided to send the auth token again rather than a fixed 5 byte message. Cost is minimal after all.