### PR TITLE
Fix for #127: Much faster MessageBuffer.EnsureLength behavior

### DIFF
--- a/DarkRift/MessageBuffer.cs
+++ b/DarkRift/MessageBuffer.cs
@@ -98,7 +98,8 @@ namespace DarkRift
             if (newLength > backingBuffer.Buffer.Length)
             {
                 //Get a new buffer and copy over data
-                AutoRecyclingArray newBackingBuffer = AutoRecyclingArray.Create(newLength);
+                int newCapacity = Math.Max(newLength, backingBuffer.Buffer.Length * 2);
+                AutoRecyclingArray newBackingBuffer = AutoRecyclingArray.Create(newCapacity);
                 Array.Copy(backingBuffer.Buffer, newBackingBuffer.Buffer, backingBuffer.Buffer.Length);
 
                 // Swap out the buffer


### PR DESCRIPTION
In the test case refered in #127, I clock the array write to 27.8 s without this fix, and 0.020 s after this fix.

I was honestly surprised the implementation does not exponentially scale buffers already. @JamJar00 were you concerned about memory use?