### PR TITLE
Added backward compatibility for client on connection

### DIFF
--- a/DarkRift.Server/Plugins/Listeners/Bichannel/AbstractBichannelListener.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/AbstractBichannelListener.cs
@@ -30,6 +30,13 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
         public abstract bool PreserveTcpOrdering { get; protected set; }
 
         /// <summary>
+        ///     The version of the protocol used. The defaults to the latest version.
+        ///     You only need to change this if you intend to retain backwards compatibility.
+        ///     Will be removed in the next major release.
+        /// </summary>
+        public abstract int BichannelProtocolVersion { get; protected set; }
+
+        /// <summary>
         ///     The maximum size the client can ask a TCP body to be without being striked.
         /// </summary>
         /// <remarks>This defaults to 65KB.</remarks>

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
@@ -14,6 +14,8 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
 {
     internal abstract class BichannelListenerBase : AbstractBichannelListener
     {
+        private const int BichannelProtocolVersion = 1;
+
         private const uint IOC_IN = 0x80000000U;
         private const uint IOC_VENDOR = 0x18000000U;
 
@@ -185,6 +187,7 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
             {
                 //Send token via TCP
                 byte[] buffer = new byte[9];                    //Version, Token * 8
+                buffer[0] = BichannelProtocolVersion;
                 BigEndianHelper.WriteBytes(buffer, 1, token);
                 acceptSocket.Send(buffer);
             }

--- a/DarkRift.SystemTesting/PartialMessagingSteps.cs
+++ b/DarkRift.SystemTesting/PartialMessagingSteps.cs
@@ -73,7 +73,7 @@ namespace DarkRift.SystemTesting
             int receivedTcp = tcpSocket.Receive(tcpBuffer);
 
             Assert.AreEqual(9, receivedTcp);
-            Assert.AreEqual(0, tcpBuffer[0]);
+            Assert.AreEqual(1, tcpBuffer[0]); //TODO: Would be better to use constant from BichannelListenerBase.BichannelProtocolVersion
 
             // Return token
             udpSocket.Send(tcpBuffer);


### PR DESCRIPTION
Adds backwards compatibility to bichannel clients given the #162 change.

Also tried to make the error messages a bit more consistent.