### PR TITLE
Fixes a couple exceptions on iOS Servers

### DIFF
--- a/DarkRift.Server/DataManager.cs
+++ b/DarkRift.Server/DataManager.cs
@@ -150,16 +150,7 @@ namespace DarkRift.Server
             this.dataDirectory = settings.Directory;
             this.logger = logger;
 
-            DirectoryInfo directory = Directory.CreateDirectory(dataDirectory);
-
-            try
-            {
-                directory.Attributes |= FileAttributes.Hidden;
-            }
-            catch (Exception)
-            {
-                //Some platforms like iOS can cause exceptions here
-            }
+            Directory.CreateDirectory(dataDirectory);
 
             pluginsFileName = Path.Combine(dataDirectory, "Plugins.xml");
 

--- a/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
+++ b/DarkRift.Server/Plugins/Listeners/Bichannel/BichannelListenerBase.cs
@@ -129,11 +129,16 @@ namespace DarkRift.Server.Plugins.Listeners.Bichannel
 
             // By default on Windows ICMP Port Unreachable messages cause the socket to close, we really don't want that
             // https://stackoverflow.com/a/74327430/2755790
+
             try
             {
-              UdpListener.IOControl(SIO_UDP_CONNRESET, new byte[] { 0x00 }, null);
+                UdpListener.IOControl(SIO_UDP_CONNRESET, new byte[] { 0x00 }, null);
             }
             catch (PlatformNotSupportedException)
+            {
+                // Not on Windows, no need to worry about the option
+            }
+            catch(SocketException)
             {
                 // Not on Windows, no need to worry about the option
             }


### PR DESCRIPTION
For my current project, I have to support LAN lobbies for PC as well as mobile. I'm making a Unity project with IL2CPP.

However, I was having two exceptions when doing this:

* Setting the data directory's hidden attribute caused an exception
* The windows workaround for UDP sockets was failing with a SocketException for "No host found"

This PR fixes both these issues in the simplest ways I can think of.

Please let me know if you need any changes, I'm happy to help.