### PR TITLE
Fix: MSbuild - incorrect set of BaseIntermediateOutputPath

### DIFF
--- a/DarkRift.Client/DarkRift.Client.csproj
+++ b/DarkRift.Client/DarkRift.Client.csproj
@@ -1,16 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- Import global props (must be done here for Version to have effect on class libraries) -->
-  <Import Project="$(ProjectDir)..\.props" />
-
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(DRBuildMode)' != 'coreonly' ">net3.5;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DRBuildMode)' == 'coreonly' ">netstandard2.0</TargetFrameworks>
     <DocumentationFile>$(OutDir)\$(Configuration)\$(TargetFramework)\DarkRift.Client.xml</DocumentationFile>
     <Configurations>Debug;Release</Configurations>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	<BaseOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net3.5' ">

--- a/DarkRift.Server.Console/DarkRift.Server.Console.csproj
+++ b/DarkRift.Server.Console/DarkRift.Server.Console.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- Import global props -->
-  <Import Project="$(ProjectDir)..\.props" />
-
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(DRBuildMode)' != 'coreonly' ">net4.0;netcoreapp2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DRBuildMode)' == 'coreonly' ">netcoreapp2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
@@ -14,8 +11,6 @@
     <!-- Don't generate a Windows exe, it doesn't work with our packing into ./lib -->
     <!-- TODO https://github.com/nulastudio/NetCoreBeauty? -->
     <UseAppHost>false</UseAppHost>
-	<BaseOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/DarkRift.Server.Testing/DarkRift.Server.Testing.csproj
+++ b/DarkRift.Server.Testing/DarkRift.Server.Testing.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- Import global props (must be done here for Version to have effect on class libraries) -->
-  <Import Project="$(ProjectDir)..\.props" />
-
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(DRBuildMode)' != 'coreonly' ">net4.5;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DRBuildMode)' == 'coreonly' ">net6.0</TargetFrameworks>
@@ -9,8 +6,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- MSTest.TestAdapter package is for .NET Framework 4.6.1 so throws errors on .NET Standard build -->
     <NoWarn>NU1701</NoWarn>
-	<BaseOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DarkRift.Server/DarkRift.Server.csproj
+++ b/DarkRift.Server/DarkRift.Server.csproj
@@ -1,16 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- Import global props (must be done here for Version to have effect on class libraries) -->
-  <Import Project="$(ProjectDir)..\.props" />
-  
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(DRBuildMode)' != 'coreonly' ">net3.5;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DRBuildMode)' == 'coreonly' ">netstandard2.0</TargetFrameworks>
     <DocumentationFile>$(OutDir)\$(Configuration)\$(TargetFramework)\DarkRift.Server.xml</DocumentationFile>
     <Configurations>Debug;Release</Configurations>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	<BaseOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net3.5' ">

--- a/DarkRift.SystemTesting/DarkRift.SystemTesting.csproj
+++ b/DarkRift.SystemTesting/DarkRift.SystemTesting.csproj
@@ -1,15 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- Import global props (must be done here for Version to have effect on class libraries) -->
-  <Import Project="$(ProjectDir)..\.props" />
-
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
-	<BaseOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DarkRift.Testing/DarkRift.Testing.csproj
+++ b/DarkRift.Testing/DarkRift.Testing.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- Import global props (must be done here for Version to have effect on class libraries) -->
-  <Import Project="$(ProjectDir)..\.props" />
-  
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(DRBuildMode)' != 'coreonly' ">net4.5;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DRBuildMode)' == 'coreonly' ">net6.0</TargetFrameworks>
@@ -10,8 +7,6 @@
     <!-- MSTest.TestAdapter package is for .NET Framework 4.6.1 so throws errors on .NET Standard build -->
     <NoWarn>NU1701</NoWarn>
     <IsPackable>false</IsPackable>
-	<BaseOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DarkRift/DarkRift.csproj
+++ b/DarkRift/DarkRift.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- Import global props (must be done here for Version to have effect on class libraries) -->
-  <Import Project="$(ProjectDir)..\.props" />
-
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(DRBuildMode)' != 'coreonly' ">net3.5;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DRBuildMode)' == 'coreonly' ">netstandard2.0</TargetFrameworks>
@@ -9,9 +6,7 @@
     <Configurations>Debug;Release</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	<BaseOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(ProjectDir)..\..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net3.5' ">
@@ -25,8 +20,8 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath=""/>
+    <None Include="..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/DarkRift/Dispatching/FunctionDispatcherTask.cs
+++ b/DarkRift/Dispatching/FunctionDispatcherTask.cs
@@ -55,7 +55,7 @@ namespace DarkRift.Dispatching
             catch (Exception e)
             {
                 SetTaskFailed(e);
-                throw new DispatcherException("An exception occurred whilst running a dispatcher task. See inner exception for more details.", e); ;
+                throw new DispatcherException("An exception occurred whilst running a dispatcher task. See inner exception for more details.", e);
             }
 
             SetTaskComplete(synchronous);

--- a/DarkRift2.sln
+++ b/DarkRift2.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.props = .props
 		.targets = .targets
 		bitbucket-pipelines.yml = bitbucket-pipelines.yml
+		Directory.Build.props = Directory.Build.props
 		ReadMe.md = ReadMe.md
 		DarkRift.Schemas\Server.config.xsd = DarkRift.Schemas\Server.config.xsd
 	EndProjectSection

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Common properties -->
+  <PropertyGroup>
+    <!-- SolutionDir is not defined when building projects explicitly -->
+    <SolutionDir Condition=" '$(SolutionDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), DarkRift2.sln))\</SolutionDir>
+    <!-- Output paths -->
+    <BaseIntermediateOutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\obj\$(Configuration)</IntermediateOutputPath>
+    <!--<BaseIntermediateOutputPath>$(SolutionDir)bin\obj\$(Configuration)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>-->
+    <!--<IntermediateOutputPath>$(SolutionDir)bin\obj\$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>-->
+    <MSBuildProjectExtensionsPath>$(IntermediateOutputPath)\</MSBuildProjectExtensionsPath>
+    <BaseOutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
+    <!--<OutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\bin\</OutputPath>-->
+    <OutDir>$(OutputPath)</OutDir>
+  </PropertyGroup>
+
+  <Import Project="$(SolutionDir)\.props" />
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,11 +7,8 @@
     <!-- Output paths -->
     <BaseIntermediateOutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\obj\$(Configuration)</IntermediateOutputPath>
-    <!--<BaseIntermediateOutputPath>$(SolutionDir)bin\obj\$(Configuration)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>-->
-    <!--<IntermediateOutputPath>$(SolutionDir)bin\obj\$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>-->
     <MSBuildProjectExtensionsPath>$(IntermediateOutputPath)\</MSBuildProjectExtensionsPath>
     <BaseOutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\bin\</BaseOutputPath>
-    <!--<OutputPath>$(SolutionDir)..\unordinal\dr-build\$(MSBuildProjectName)\bin\</OutputPath>-->
     <OutDir>$(OutputPath)</OutDir>
   </PropertyGroup>
 


### PR DESCRIPTION
See MSBuild issue bellow:
[Setting BaseIntermediateOutputPath correctly in a SDK-based project](https://github.com/dotnet/msbuild/issues/1603)

Build at the previous state produced warnings as the following one:

`C:\Program Files\dotnet\sdk\7.0.203\Microsoft.Common.CurrentVersion.targets(870,5): warning MSB3539: The value of the property "BaseIntermediateOutputPath" was modified after it was used by MSBuild which can lead to unexpected build results. Tools such as NuGet will write outputs to the path specified by the "MSBuildProjectExtensionsPath" instead. To set this property, you must do so before Microsoft.Common.props is imported, for example by using Directory.Build.props.  For more information, please visit https://go.microsoft.com/fwlink/?linkid=869650`

Every $(ProjectDir) was also populated with 'obj' folder containing project.nuget.g.props\targets after build.

it should be now at ../unordinal/dr-build/<project>/obj