### PR TITLE
DefaultItemExcludes modified to exclude unity .meta files from all projects

### DIFF
--- a/.props
+++ b/.props
@@ -10,4 +10,7 @@
 		<Copyright>Unordinal AB</Copyright>
 		<Description>DarkRift Networking - High Performance Networking Library for .NET and Unity Games</Description>
 	</PropertyGroup>
+  <PropertyGroup>
+    <DefaultItemExcludes>$(DefaultItemExcludes);*.meta</DefaultItemExcludes>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Unity meta files are automatically generated by Unity editor and are not supposed to be modified manually. They also do not need to be part of the build. Therefore it does not make much sense to keep them present in project as they would only hinder.

With Unity meta files:
![with_meta](https://github.com/DarkRiftNetworking/DarkRift/assets/3914266/77c01ae9-c24b-4353-84c2-57a4001645d3)

Without Unity meta files:
![without_meta](https://github.com/DarkRiftNetworking/DarkRift/assets/3914266/6aadd778-6c50-4f52-8ed0-aa1179adc822)
