### PR TITLE
Fix: BichannelClientConnection - TcpSendCompleted event handler unhook

### DIFF
--- a/DarkRift.Client/BichannelClientConnection.cs
+++ b/DarkRift.Client/BichannelClientConnection.cs
@@ -301,7 +301,7 @@ namespace DarkRift.Client
             catch (Exception)
             {
                 message.Dispose();
-                args.Completed += TcpSendCompleted;
+                args.Completed -= TcpSendCompleted;
                 ObjectCache.ReturnSocketAsyncEventArgs(args);
                 return false;
             }


### PR DESCRIPTION
Fixed: 
 - SocketAsyncEventArgs.Completed event had an event handler hooked by mistake when SendAsync failed with an exception.

It was properly unhooked in same place for BichannelServerConnection.

