### PR TITLE
Add factory method to create a Message by from tag and IMessageBuffer

### DIFF
--- a/DarkRift/Message.cs
+++ b/DarkRift/Message.cs
@@ -194,11 +194,21 @@ namespace DarkRift
         }
 
         /// <summary>
+        ///     Creates a new message with the given tag and data.
+        /// </summary>
+        /// <param name="tag">The tag the message has.</param>
+        /// <param name="data">The initial data in the message.</param>
+        public static Message Create(ushort tag, byte[] data)
+        {
+            return Create(tag, new UnmanagedMemoryBuffer(data, 0, data.Length));
+        }
+
+        /// <summary>
         ///     Creates a new message with the given tag and message buffer.
         /// </summary>
         /// <param name="tag">The tag the message has.</param>
         /// <param name="buffer">The initial data in the message.</param>
-        public static Message Create(ushort tag, IMessageBuffer buffer)
+        private static Message Create(ushort tag, IMessageBuffer buffer)
         {
             Message message = ObjectCache.GetMessage();
 

--- a/DarkRift/Message.cs
+++ b/DarkRift/Message.cs
@@ -190,12 +190,22 @@ namespace DarkRift
         /// <param name="writer">The initial data in the message.</param>
         public static Message Create(ushort tag, DarkRiftWriter writer)
         {
+            return Create(tag, writer.ToBuffer());
+        }
+
+        /// <summary>
+        ///     Creates a new message with the given tag and message buffer.
+        /// </summary>
+        /// <param name="tag">The tag the message has.</param>
+        /// <param name="buffer">The initial data in the message.</param>
+        public static Message Create(ushort tag, IMessageBuffer buffer)
+        {
             Message message = ObjectCache.GetMessage();
 
             message.isCurrentlyLoungingInAPool = false;
 
             message.IsReadOnly = false;
-            message.buffer = writer.ToBuffer();
+            message.buffer = buffer;
             message.tag = tag;
             message.flags = 0;
             message.PingCode = 0;
@@ -268,7 +278,7 @@ namespace DarkRift
 
             // We clone the message buffer so we can modify it's properties safely
             message.buffer = buffer.Clone();
-            
+
             //Get flags first so we can query it
             message.flags = buffer.Buffer[buffer.Offset];
 
@@ -289,7 +299,7 @@ namespace DarkRift
         /// </summary>
         internal Message()
         {
-            
+
         }
 
         /// <summary>
@@ -448,7 +458,7 @@ namespace DarkRift
 
             //We don't want to give a reference to our buffer so we need to clone it
             message.buffer = buffer.Clone();
-            
+
             message.flags = flags;
             message.tag = tag;
             message.PingCode = PingCode;


### PR DESCRIPTION
Currently the only way to get pre-serialized Data (`byte[]`) into a Message is by either using `DarkRift.DarkRiftWriter.WriteRaw` and passing the Writer to Message factory method or by passing an object implementing `IDarkRiftSerializable`.

Both ways will cause an unnecessary memory copy of the data.

Luckily `IMessageBuffer` is public, so we could write this:

```
public class ByteArrayMappingMessageBuffer : IMessageBuffer {
  public ByteArrayMappingMessageBuffer(byte[] buffer) {
    Buffer = buffer;
  }

  public void Dispose() {
    throw new System.NotImplementedException();
  }

  public IMessageBuffer Clone() {
    throw new System.NotImplementedException();
  }

  public byte[] Buffer { get; }

  public int Count {
    get => Buffer.Length;
    set => throw new System.NotImplementedException();
  }

  public int Offset {
    get => 0;
    set => throw new System.NotImplementedException();
  }
}
```

The PR adds a new method to `Message` allowing to not only pass a `DarkRiftWriter` but an `IMessageBuffer` directly.
Passing the one above will allow us to create and send a Message using pre-serialized data and also helps separating Serialization from Networking.

```
byte[] serializedData = ...;
var buffer = new ByteArrayMappingMessageBuffer(serializedData);
Message message = Message.Create(message.Tag, buffer);
client.SendMessage(message, sendMode);
```